### PR TITLE
remove unneeded module dependencies

### DIFF
--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -18,15 +18,11 @@
 
     <require_modules>
         <require_module version="${emrapiVersion}">org.openmrs.module.emrapi</require_module>
-        <require_module version="${paperrecordVersion}">org.openmrs.module.paperrecord</require_module>
         <require_module version="${uiframeworkVersion}">org.openmrs.module.uiframework</require_module>
         <require_module version="${appframeworkVersion}">org.openmrs.module.appframework</require_module>
         <require_module version="${htmlformentryVersion}">org.openmrs.module.htmlformentry</require_module>
-        <require_module version="${providermanagementVersion}">org.openmrs.module.providermanagement</require_module>
         <require_module version="${idgenVersion}">org.openmrs.module.idgen</require_module>
         <require_module version="${reportingVersion}">org.openmrs.module.reporting</require_module>
-        <require_module version="${uicommonsVersion}">org.openmrs.module.uicommons</require_module>
-        <require_module version="${metadatasharingVersion}">org.openmrs.module.metadatasharing</require_module>
         <require_module version="${metadatamappingVersion}">org.openmrs.module.metadatamapping</require_module>
 	</require_modules>
 

--- a/pom.xml
+++ b/pom.xml
@@ -38,14 +38,11 @@
         <appframeworkVersion>2.17.0</appframeworkVersion>
         <idgenVersion>4.10.0</idgenVersion>
         <htmlformentryVersion>3.13.1</htmlformentryVersion>
-        <providermanagementVersion>2.14.0</providermanagementVersion>
-        <metadatasharingVersion>1.9.0</metadatasharingVersion>
         <metadatamappingVersion>1.6.0</metadatamappingVersion>
         <reportingVersion>1.26.0</reportingVersion>
         <calculationVersion>1.3.0</calculationVersion>
         <serializationxstreamVersion>0.2.16</serializationxstreamVersion>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <uicommonsVersion>2.25.0</uicommonsVersion>
         <htmlformentryuiVersion>2.3.0</htmlformentryuiVersion>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -38,19 +38,15 @@
         <appframeworkVersion>2.16.0</appframeworkVersion>
         <idgenVersion>4.8.0</idgenVersion>
         <htmlformentryVersion>3.13.1</htmlformentryVersion>
-        <providermanagementVersion>2.13.0</providermanagementVersion>
-        <metadatasharingVersion>1.8.0</metadatasharingVersion>
         <metadatamappingVersion>1.5.0</metadatamappingVersion>
         <reportingVersion>1.24.0</reportingVersion>
         <calculationVersion>1.3.0</calculationVersion>
         <serializationxstreamVersion>0.2.15</serializationxstreamVersion>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <uicommonsVersion>2.21.0</uicommonsVersion>
         <htmlformentryuiVersion>2.1.0</htmlformentryuiVersion>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>
-
         <!-- Begin OpenMRS core -->
 
         <dependency>
@@ -156,12 +152,7 @@
             <version>${htmlformentryVersion}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.openmrs.module</groupId>
-            <artifactId>providermanagement-api</artifactId>
-            <version>${providermanagementVersion}</version>
-            <scope>provided</scope>
-        </dependency>
+
         <dependency>
             <groupId>org.openmrs.module</groupId>
             <artifactId>reporting-api</artifactId>
@@ -200,19 +191,7 @@
         </dependency>
 
         <!-- OpenMRS modules required for testing -->
-        <dependency>
-            <groupId>org.openmrs.module</groupId>
-            <artifactId>metadatasharing-api</artifactId>
-            <version>${metadatasharingVersion}</version>
-            <scope>test</scope>
-        </dependency>
 
-        <dependency>
-            <groupId>org.openmrs.module</groupId>
-            <artifactId>uicommons-api</artifactId>
-            <version>${uicommonsVersion}</version>
-            <scope>provided</scope>
-        </dependency>
 
         <dependency>
             <groupId>org.openmrs.module</groupId>


### PR DESCRIPTION
Removing the dependency on the Metadata Sharing module so we can remove it from our distro.  Also removed some other dependencies that weren't being used anymore.

There's probably further functionality we an remove but I didn't address any modules were removing them led to compile errors.